### PR TITLE
remove opam from virtual/sandboxes initialization

### DIFF
--- a/bash/00-virtual.bash
+++ b/bash/00-virtual.bash
@@ -21,7 +21,7 @@ esac
 # pnpm end
 
 # opam configuration
-[[ ! -r "$HOME/.opam/opam-init/init.zsh" ]] || source "$HOME/.opam/opam-init/init.zsh" >/dev/null 2>/dev/null
+# [[ ! -r "$HOME/.opam/opam-init/init.zsh" ]] || source "$HOME/.opam/opam-init/init.zsh" >/dev/null 2>/dev/null
 
 # phpenv
 if [[ -d "$HOME/.config/phpenv" ]]; then


### PR DESCRIPTION
I am still use Opam in few projects. But I migrate to Nix